### PR TITLE
Dockerfile: use weekly-cached base-docker-images

### DIFF
--- a/assets/Dockerfile
+++ b/assets/Dockerfile
@@ -1,40 +1,15 @@
+ARG builder_image_tag=builder
+ARG tags
+ARG runner_image_tag=runner
+ARG entrypoint
 
-ARG debian_version=bookworm-slim
-FROM golang:1 AS builder
-
-ENV GOPATH /build/_local
-ENV GO111MODULE=on
-ENV GOPROXY="https://proxy.golang.org"
-
-ARG packages
-RUN if [ -n "$packages" ]; then \
-      DEBIAN_FRONTEND=noninteractive \
-      apt-get update && \
-      apt-get install -y --no-install-recommends ${packages} && \
-      apt-get clean && \
-      rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*; \
-    fi
-
+FROM ghcr.io/remotely-works/base-docker-images:${builder_image_tag} AS builder
 WORKDIR /build
 COPY . .
-
-ARG tags
-ARG goprivate
-ENV GOPRIVATE="${goprivate}"
 RUN go install -tags "${tags}" ./...
-
 RUN ls /build/_local/bin
 
-FROM debian:${debian_version}
-
-ARG packages
-RUN DEBIAN_FRONTEND=noninteractive \
-    apt-get update && \
-    apt-get install -y --no-install-recommends ca-certificates ${packages} && \
-    apt-get clean && \
-    rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
-
-ARG entrypoint
+FROM ghcr.io/remotely-works/base-docker-images:${runner_image_tag}
 COPY --from=builder /build/_local/bin /usr/local/bin
 RUN echo "#!/bin/sh\n${entrypoint} \"\$@\"" > /bin/entrypoint.sh && chmod +x /bin/entrypoint.sh
 ENTRYPOINT [ "/bin/entrypoint.sh" ]


### PR DESCRIPTION
@jfontan @erizocosmico @dpordomingo 

I've setup https://github.com/remotely-works/base-docker-images with two base Dockerfiles, one for the builder and one for the runner.

Currently these are the available/built tags:
- `ghcr.io/remotely-works/base-docker-images:builder`
- `ghcr.io/remotely-works/base-docker-images:runner`
- `ghcr.io/remotely-works/base-docker-images:runner-wkhtmltopdf`

They get [rebuilt every Sunday](https://github.com/remotely-works/base-docker-images/blob/2af7baa223a9ee8676e8520f78417219a9e64b3e/.github/workflows/docker.yml#L8-L9).

The purpose of this is avoid doing IO operations in GitHub Actions as much as possible, which has been proved to be awful, to speedup build times.

References:
- Issue: https://github.com/remotely-works/platform/issues/2782
- PR: https://github.com/remotely-works/platform/pull/2798
